### PR TITLE
Adding correct password controller namespace

### DIFF
--- a/routes/settings.php
+++ b/routes/settings.php
@@ -1,7 +1,7 @@
 <?php
 
-use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\PasswordController;
+use App\Http\Controllers\Settings\ProfileController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 


### PR DESCRIPTION
This PR will fix the tests and add the correct password controller so an error does not occur in the `/settings/password` page.