### PR TITLE
Remove `postcss` and `@tailwindcss/postcss` dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
             "devDependencies": {
                 "@eslint/js": "^9.19.0",
                 "@inertiajs/react": "^2.0.0",
-                "@tailwindcss/postcss": "^4.0.0",
                 "@types/react": "^19.0.3",
                 "@types/react-dom": "^19.0.2",
                 "@vitejs/plugin-react": "^4.3.4",
@@ -40,7 +39,6 @@
                 "eslint-plugin-react-hooks": "^5.1.0",
                 "globals": "^15.14.0",
                 "laravel-vite-plugin": "^1.0",
-                "postcss": "^8.4.49",
                 "prettier": "^3.4.2",
                 "prettier-plugin-organize-imports": "^4.1.0",
                 "prettier-plugin-tailwindcss": "^0.6.11",
@@ -50,19 +48,6 @@
                 "typescript": "^5.7.2",
                 "typescript-eslint": "^8.23.0",
                 "vite": "^6.0"
-            }
-        },
-        "node_modules/@alloc/quick-lru": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-            "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -2647,28 +2632,6 @@
             "engines": {
                 "node": ">= 10"
             }
-        },
-        "node_modules/@tailwindcss/postcss": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.0.0.tgz",
-            "integrity": "sha512-lI2bPk4TvwavHdehjr5WiC6HnZ59hacM6ySEo4RM/H7tsjWd8JpqiNW9ThH7rO/yKtrn4mGBoXshpvn8clXjPg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@alloc/quick-lru": "^5.2.0",
-                "@tailwindcss/node": "^4.0.0",
-                "@tailwindcss/oxide": "^4.0.0",
-                "lightningcss": "^1.29.1",
-                "postcss": "^8.4.41",
-                "tailwindcss": "4.0.0"
-            }
-        },
-        "node_modules/@tailwindcss/postcss/node_modules/tailwindcss": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0.tgz",
-            "integrity": "sha512-ULRPI3A+e39T7pSaf1xoi58AqqJxVCLg8F/uM5A3FadUbnyDTgltVnXJvdkTjwCOGA6NazqHVcwPJC5h2vRYVQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@tailwindcss/vite": {
             "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@inertiajs/react": "^2.0.0",
-        "@tailwindcss/postcss": "^4.0.0",
         "@types/react": "^19.0.3",
         "@types/react-dom": "^19.0.2",
         "@vitejs/plugin-react": "^4.3.4",
@@ -23,7 +22,6 @@
         "eslint-plugin-react-hooks": "^5.1.0",
         "globals": "^15.14.0",
         "laravel-vite-plugin": "^1.0",
-        "postcss": "^8.4.49",
         "prettier": "^3.4.2",
         "prettier-plugin-organize-imports": "^4.1.0",
         "prettier-plugin-tailwindcss": "^0.6.11",


### PR DESCRIPTION
Tailwind CSS v4 is using the Vite plugin in this starter kit — there is no reason to keep the PostCSS and `@tailwindcss/postcss` dependencies in here.

I don't see a PostCSS configuration anywhere, and have ran the starter kit without PostCSS, everything seems to work fine.