### PR TITLE
Only apply active styles to active link in app header nav links

### DIFF
--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -43,7 +43,8 @@ interface AppHeaderProps {
 }
 
 export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
-    const { auth } = usePage<SharedData>().props;
+    const page = usePage<SharedData>();
+    const { auth } = page.props;
     const getInitials = useInitials();
     return (
         <>
@@ -105,12 +106,18 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                                     <NavigationMenuItem key={index} className="relative flex h-full items-center">
                                         <Link
                                             href={item.url}
-                                            className={cn(navigationMenuTriggerStyle(), activeItemStyles, 'h-9 cursor-pointer px-3')}
+                                            className={cn(
+                                                navigationMenuTriggerStyle(),
+                                                page.url === item.url && activeItemStyles,
+                                                'h-9 cursor-pointer px-3',
+                                            )}
                                         >
                                             {item.icon && <Icon iconNode={item.icon} className="mr-2 h-4 w-4" />}
                                             {item.title}
                                         </Link>
-                                        <div className="absolute bottom-0 left-0 h-0.5 w-full translate-y-px bg-black dark:bg-white"></div>
+                                        {page.url === item.url && (
+                                            <div className="absolute bottom-0 left-0 h-0.5 w-full translate-y-px bg-black dark:bg-white"></div>
+                                        )}
                                     </NavigationMenuItem>
                                 ))}
                             </NavigationMenuList>


### PR DESCRIPTION
## Current status

Looks like the "active" navigation styles for the "App Header" layout are applied to all links — I discovered this when trying to add extra links to demo the starter kit customisation:

![CleanShot 2025-02-19 at 10 40 18@2x](https://github.com/user-attachments/assets/283b5acd-bc56-447c-8605-cf2756e9625e)

---

## Proposed change

This PR uses the `page.url` from `usePage()` to compare with each link's `url` value, and conditionally apply the extra styles.

This is how it looks with the new code:

![CleanShot 2025-02-19 at 10 39 26@2x](https://github.com/user-attachments/assets/741f6ffe-ef19-4e7f-9bf2-270a8477ab40)
