### PR TITLE
Simplify imports in useIsMobile hook

### DIFF
--- a/resources/js/hooks/use-mobile.tsx
+++ b/resources/js/hooks/use-mobile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState } from 'react';
 
 const MOBILE_BREAKPOINT = 768;
 

--- a/resources/js/hooks/use-mobile.tsx
+++ b/resources/js/hooks/use-mobile.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import { useEffect, useState } from "react";
 
 const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
-    const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);
+    const [isMobile, setIsMobile] = useState<boolean | undefined>(undefined);
 
-    React.useEffect(() => {
+    useEffect(() => {
         const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
 
         const onChange = () => {


### PR DESCRIPTION
This merge request now imports the `useEffect` and `useState` hooks directly from 'react' rather than using a namespace import in the `useMobile` hook. This change ensures consistency with the import style already used in the `useAppearance` and `useMobileNavigation` hooks. 