### PR TITLE
Use Route::inertia directly in web.php

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -6,5 +6,5 @@ Route::inertia('/', 'welcome')->name('home');
 
 Route::inertia('/dashboard', 'dashboard')->name('dashboard')->middleware('auth');
 
-require __DIR__ . '/settings.php';
-require __DIR__ . '/auth.php';
+require __DIR__.'/settings.php';
+require __DIR__.'/auth.php';

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,17 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use Inertia\Inertia;
 
-Route::get('/', function () {
-    return Inertia::render('welcome');
-})->name('home');
+Route::inertia('/', 'welcome')->name('home');
 
-Route::middleware(['auth'])->group(function () {
-    Route::get('dashboard', function () {
-        return Inertia::render('dashboard');
-    })->name('dashboard');
-});
+Route::inertia('/dashboard', 'dashboard')->name('dashboard')->middleware('auth');
 
-require __DIR__.'/settings.php';
-require __DIR__.'/auth.php';
+require __DIR__ . '/settings.php';
+require __DIR__ . '/auth.php';


### PR DESCRIPTION
This merge request changes the route definitions inside `web.php` to use `Route::inertia` directly instead of `Route::get` with nested Inertia rendering. This cleans up the file and removes the Inertia import at the top. 

