### PR TITLE
ci: check formatting instead of actually formatting files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Run Pint
         run: vendor/bin/pint
 
-      - name: Format Frontend
-        run: npm run format
+      - name: Check Frontend Formatting
+        run: npm run format:check
 
       - name: Lint Frontend
         run: npm run lint


### PR DESCRIPTION
Amazing job on the new boilerplates! 🥳

In CI/CD, I usually check if the formatting is correct, rather than do the actual formatting.
This way the job fails, if files are not formatted properly.

Currently, the job would be successful, even if there are improperly formatted files.
This PR changes this to check the formatting, rather than formatting it.

What do you think?

EDIT: if this is wanted, I can also add a PR to the Vue starter kit