### PR TITLE
ci: use php artisan test over phpunit command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,4 +50,4 @@ jobs:
         run: php artisan key:generate
 
       - name: Tests
-        run: ./vendor/bin/phpunit
+        run: php artisan test


### PR DESCRIPTION
This PR changes the test command from `./vendor/bin/phpunit` to `php artisan test`.

EDIT: if this is wanted, I can also add a PR to the other starter kits