### PR TITLE
style: fix dark mode for header layout

### DIFF
--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -58,7 +58,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                                     <Menu className="h-5 w-5" />
                                 </Button>
                             </SheetTrigger>
-                            <SheetContent side="left" className="flex h-full w-64 flex-col items-stretch justify-between bg-neutral-50">
+                            <SheetContent side="left" className="flex h-full w-64 flex-col items-stretch justify-between bg-sidebar">
                                 <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
                                 <SheetHeader className="flex justify-start text-left">
                                     <AppLogoIcon className="h-6 w-6 fill-current text-black dark:text-white" />


### PR DESCRIPTION
This PR fixes a dark mode issue where the sidebar sheet appears broken in the header layout.

Before:
<img width="564" alt="Screenshot 2025-02-24 at 6 54 51 PM" src="https://github.com/user-attachments/assets/f03b3b1c-69ff-4310-9fe3-1c8a69163c2a" />

After:
<img width="581" alt="Screenshot 2025-02-24 at 6 51 56 PM" src="https://github.com/user-attachments/assets/d6f561a2-5bd2-476a-9206-657a488e5627" />
