### PR TITLE
fix: type assertion in useAppearance hook

### DIFF
--- a/resources/js/hooks/use-appearance.tsx
+++ b/resources/js/hooks/use-appearance.tsx
@@ -36,7 +36,7 @@ export function useAppearance() {
     };
 
     useEffect(() => {
-        const savedAppearance = localStorage.getItem('appearance') as Appearance;
+        const savedAppearance = localStorage.getItem('appearance') as Appearance | null;
         updateAppearance(savedAppearance || 'system');
 
         return () => mediaQuery.removeEventListener('change', handleSystemThemeChange);


### PR DESCRIPTION
Hello, looking further through the start kit and it looks really good, I love it!

One small thing I found: Since `localStorage.getItem` returns `string | null`, the type assertion should reflect the `| null` part as well. In this use case it does not matter, since the value of `savedAppearance` is only used in the line below, and it is defaulted there, but the assertion should be done properly.