### PR TITLE
Add preserveScroll option to profile update request

### DIFF
--- a/resources/js/pages/settings/profile.tsx
+++ b/resources/js/pages/settings/profile.tsx
@@ -30,7 +30,9 @@ export default function Profile({ mustVerifyEmail, status }: { mustVerifyEmail: 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
 
-        patch(route('profile.update'));
+        patch(route('profile.update'), {
+            preserveScroll: true,
+        });
     };
 
     return (


### PR DESCRIPTION
This PR updates the submit function in `resources/js/pages/settings/profile.tsx` to preserve the scroll position after a profile update.