### PR TITLE
Adjust wording in Welcome.tsx

### DIFF
--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -45,7 +45,7 @@ export default function Welcome() {
                             <p className="mb-2 text-[#706f6c] dark:text-[#A1A09A]">
                                 Laravel has an incredibly rich ecosystem.
                                 <br />
-                                We suggest you start with the following.
+                                We suggest starting with the following.
                             </p>
                             <ul className="mb-4 flex flex-col lg:mb-6">
                                 <li className="relative flex items-center gap-4 py-2 before:absolute before:top-1/2 before:bottom-0 before:left-[0.4rem] before:border-l before:border-[#e3e3e0] dark:before:border-[#3E3E3A]">


### PR DESCRIPTION
This merge request only changes the wording from "We suggest _you start_ with the following." to "We suggest _starting_ with the following." to match the wording in the Livewire and Vue starter kits.

Additionally, it seems that the Welcome.vue file in the Vue starter kit needs adjustment, as it looks like it has extra margin at the top of the card, unlike the other kits.