### PR TITLE
fix: PlaceholderPattern component prop 'stroke-width' updated to 'strokeWidth'

### DIFF
--- a/resources/js/components/ui/placeholder-pattern.tsx
+++ b/resources/js/components/ui/placeholder-pattern.tsx
@@ -11,7 +11,7 @@ export function PlaceholderPattern({ className }: PlaceholderPatternProps) {
         <svg className={className} fill="none">
             <defs>
                 <pattern id={patternId} x="0" y="0" width="8" height="8" patternUnits="userSpaceOnUse">
-                    <path d="M-1 5L5 -1M3 9L8.5 3.5" stroke-width="0.5"></path>
+                    <path d="M-1 5L5 -1M3 9L8.5 3.5" strokeWidth="0.5"></path>
                 </pattern>
             </defs>
             <rect stroke="none" fill={`url(#${patternId})`} width="100%" height="100%"></rect>


### PR DESCRIPTION
The current prop, as `stroke-width` causes a `@react-refresh:267 Invalid DOM property 'stroke-width'` error, as shown below

![image](https://github.com/user-attachments/assets/6e9836e3-33fb-4bd7-9894-f86c5da35cfe)

Changing it to strokeWidth fixes it