### PR TITLE
Use Route::inertia in routes/settings.php

### DIFF
--- a/routes/settings.php
+++ b/routes/settings.php
@@ -3,7 +3,6 @@
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
 use Illuminate\Support\Facades\Route;
-use Inertia\Inertia;
 
 Route::middleware('auth')->group(function () {
     Route::redirect('settings', 'settings/profile');
@@ -15,7 +14,5 @@ Route::middleware('auth')->group(function () {
     Route::get('settings/password', [PasswordController::class, 'edit'])->name('password.edit');
     Route::put('settings/password', [PasswordController::class, 'update'])->name('password.update');
 
-    Route::get('settings/appearance', function () {
-        return Inertia::render('settings/appearance');
-    })->name('appearance');
+    Route::inertia('settings/appearance', 'settings/appearance')->name('appearance');
 });


### PR DESCRIPTION
I understand that a similar PR was closed for the `routes/web.php` file because it might fetch data. However, this isn’t the case for `routes/settings.php`. I can’t seem to find the WorkOS version of settings.php, and if this PR is accepted, it will also need a similar update. 