### PR TITLE
refactor: make href for bradcurmItem optional and add fallback href

### DIFF
--- a/resources/js/components/breadcrumbs.tsx
+++ b/resources/js/components/breadcrumbs.tsx
@@ -18,7 +18,7 @@ export function Breadcrumbs({ breadcrumbs }: { breadcrumbs: BreadcrumbItemType[]
                                             <BreadcrumbPage>{item.title}</BreadcrumbPage>
                                         ) : (
                                             <BreadcrumbLink asChild>
-                                                <Link href={item.href}>{item.title}</Link>
+                                                <Link href={item.href ?? '#'}>{item.title}</Link>
                                             </BreadcrumbLink>
                                         )}
                                     </BreadcrumbItem>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -6,7 +6,7 @@ export interface Auth {
 
 export interface BreadcrumbItem {
     title: string;
-    href: string;
+    href?: string;
 }
 
 export interface NavGroup {


### PR DESCRIPTION
- Keep the types consistent type by making href optional and adding flexibility for usage.
- Also, add a fallback href to make it more useful.