### PR TITLE
Remove SSR folder from source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ yarn-error.log
 /.nova
 /.vscode
 /.zed
+/bootstrap/ssr


### PR DESCRIPTION
Great work with these kits! One minor thing, looks like the `bootstrap/ssr` folder isn't being ignored by source control. Added that folder to the `.gitignore` file to fix that.

Same [change](https://github.com/laravel/vue-starter-kit/pull/47) can be found in the Vue starter kit as well.