### PR TITLE
Remove unnecessary SQLite file creation in test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Build Assets
         run: npm run build
 
-      - name: Create SQLite Database
-        run: touch database/database.sqlite
-
       - name: Install Dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 


### PR DESCRIPTION
In the test workflow (tests.yml), SQLite file creation is included.
However, since `phpunit.xml` configures SQLite to run **in memory** during test execution, SQLite file is not needed in the test CI.

https://github.com/laravel/react-starter-kit/blob/c42787ad1b1adb5aa4907aa873a241728ce0159d/phpunit.xml#L25-L26

I’ve also submitted same PRs for the Vue and Livewire starter kits:
Vue: https://github.com/laravel/vue-starter-kit/pull/56
Livewire: https://github.com/laravel/livewire-starter-kit/pull/34