### PR TITLE
`@source` resources/views

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -2,6 +2,7 @@
 
 @plugin 'tailwindcss-animate';
 
+@source "../views";
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
 
 @custom-variant dark (&:is(.dark *));


### PR DESCRIPTION
As of now, the `font-sans antialiased` classes in the [body tag](https://github.com/laravel/react-starter-kit/blob/main/resources/views/app.blade.php#L17) are being ignored by Tailwind.

To recapitulate, Tailwind V4 (at least with Vite) reads content from 2 sources: 1) the modules processed by Vite; 2) the paths that were specified with the `@source` directive.

There's also the option to simply `@apply` those classes in app.css instead of the body tag, but sourcing the views seems a broader solution.