### PR TITLE
"weird" hamburger menu with header layout on mobile view

### DIFF
--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -63,7 +63,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                                 <SheetHeader className="flex justify-start text-left">
                                     <AppLogoIcon className="h-6 w-6 fill-current text-black dark:text-white" />
                                 </SheetHeader>
-                                <div className="mt-6 flex h-full flex-1 flex-col space-y-4">
+                                <div className="p-4 flex h-full flex-1 flex-col space-y-4">
                                     <div className="flex h-full flex-col justify-between text-sm">
                                         <div className="flex flex-col space-y-4">
                                             {mainNavItems.map((item) => (


### PR DESCRIPTION
There is a bit of an unsightly look to the header layout when the hamburger menu is opened on a mobile device, simply need more padding. In this PR, I added padding for the hamburger menu. Maybe this is still for other starter kits, so please review for other starter kits. Thank you.

|Before|After|
|---|---|
|![Screenshot_20250227_192615.jpg](https://github.com/user-attachments/assets/44270769-f8c9-46f5-9aec-ee2b7e7bbb52)|![Screenshot_20250227_192150.jpg](https://github.com/user-attachments/assets/24508e93-87af-47c4-bf79-f2bfa7694022)|