### PR TITLE
Make heading consistent with vue starter kit

### DIFF
--- a/resources/js/components/heading.tsx
+++ b/resources/js/components/heading.tsx
@@ -1,9 +1,12 @@
+import { Separator } from '@/components/ui/separator';
+
 export default function Heading({ title, description }: { title: string; description?: string }) {
     return (
         <>
             <div className="mb-8 space-y-0.5">
                 <h2 className="text-xl font-semibold tracking-tight">{title}</h2>
                 {description && <p className="text-muted-foreground text-sm">{description}</p>}
+                <Separator className="my-6" />
             </div>
         </>
     );


### PR DESCRIPTION
This PR adds the separator to the bottom of `Header.vue` to match the vue starter kit (ignore commit name 😅)