### PR TITLE
Remember Me Checkbox State Binding in Login Page

### DIFF
--- a/resources/js/pages/auth/login.tsx
+++ b/resources/js/pages/auth/login.tsx
@@ -80,7 +80,7 @@ export default function Login({ status, canResetPassword }: LoginProps) {
                     </div>
 
                     <div className="flex items-center space-x-3">
-                        <Checkbox id="remember" name="remember" tabIndex={3} />
+                        <Checkbox checked={data.remember} id="remember" name="remember" tabIndex={3} />
                         <Label htmlFor="remember">Remember me</Label>
                     </div>
 


### PR DESCRIPTION
This PR fixes the "Remember Me" checkbox state binding issue on the login page.

The checkbox was rendered without the checked attribute, which caused the checkbox state to not reflect the remember value from the useForm data.