### PR TITLE
Remember Me Checkbox State Binding in Login Page

### DIFF
--- a/resources/js/pages/auth/login.tsx
+++ b/resources/js/pages/auth/login.tsx
@@ -80,7 +80,7 @@ export default function Login({ status, canResetPassword }: LoginProps) {
                     </div>
 
                     <div className="flex items-center space-x-3">
-                        <Checkbox id="remember" name="remember" tabIndex={3} />
+                        <Checkbox checked={data.remember} onClick={() => setData('remember', !data.remember)} id="remember" name="remember" tabIndex={3} />
                         <Label htmlFor="remember">Remember me</Label>
                     </div>
 


### PR DESCRIPTION
Fix: "Remember Me" Checkbox State Binding on Login Page

This PR resolves the issue where the "Remember Me" checkbox state did not reflect the remember value from the useForm data.

The checkbox was rendered without the checked attribute, causing it to always appear unchecked, even when the remember value was set to true.

Although the checkbox functioned correctly with the default remember: false, this issue became noticeable when the remember value was intentionally set to true.