### PR TITLE
fix: remove left margin when sidebar is collapsed

### DIFF
--- a/resources/js/components/ui/sidebar.tsx
+++ b/resources/js/components/ui/sidebar.tsx
@@ -305,7 +305,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
       data-slot="sidebar-inset"
       className={cn(
         "bg-background relative flex min-h-svh flex-1 flex-col",
-        "peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        "peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-0",
         className
       )}
       {...props}


### PR DESCRIPTION
Previously, when the sidebar was collapsed, an unnecessary left margin was still applied to the main content, causing a misalignment. This commit removes the left margin when the sidebar is in a collapsed state, ensuring proper alignment.

**Changes**
Removed the left margin that was applied even when the sidebar was collapsed.
Ensured that the main content aligns correctly with the sidebar's state.
Before & After

**Before (Issue)**

- Sidebar collapsed, but main content has unnecessary left margin.

**After (Fix Applied)**

- Sidebar collapsed, and main content is now properly aligned.

