### PR TITLE
Fix inertia page testing fails because of wrong page path

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -1,0 +1,73 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Server Side Rendering
+    |--------------------------------------------------------------------------
+    |
+    | These options configures if and how Inertia uses Server Side Rendering
+    | to pre-render the initial visits made to your application's pages.
+    |
+    | You can specify a custom SSR bundle path, or omit it to let Inertia
+    | try and automatically detect it for you.
+    |
+    | Do note that enabling these options will NOT automatically make SSR work,
+    | as a separate rendering service needs to be available. To learn more,
+    | please visit https://inertiajs.com/server-side-rendering
+    |
+    */
+
+    'ssr' => [
+
+        'enabled' => true,
+
+        'url' => 'http://127.0.0.1:13714',
+
+        // 'bundle' => base_path('bootstrap/ssr/ssr.mjs'),
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Testing
+    |--------------------------------------------------------------------------
+    |
+    | The values described here are used to locate Inertia components on the
+    | filesystem. For instance, when using `assertInertia`, the assertion
+    | attempts to locate the component as a file relative to any of the
+    | paths AND with any of the extensions specified here.
+    |
+    */
+
+    'testing' => [
+
+        'ensure_pages_exist' => true,
+
+        'page_paths' => [
+
+            resource_path('js/Pages'),
+
+        ],
+
+        'page_extensions' => [
+
+            'js',
+            'jsx',
+            'svelte',
+            'ts',
+            'tsx',
+            'vue',
+
+        ],
+
+    ],
+
+    'history' => [
+
+        'encrypt' => false,
+
+    ],
+
+];

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -47,7 +47,7 @@ return [
 
         'page_paths' => [
 
-            resource_path('js/Pages'),
+            resource_path('js/pages'),
 
         ],
 

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -20,11 +20,8 @@ return [
     */
 
     'ssr' => [
-
         'enabled' => true,
-
         'url' => 'http://127.0.0.1:13714',
-
         // 'bundle' => base_path('bootstrap/ssr/ssr.mjs'),
 
     ],
@@ -46,28 +43,22 @@ return [
         'ensure_pages_exist' => true,
 
         'page_paths' => [
-
             resource_path('js/pages'),
-
         ],
 
         'page_extensions' => [
-
             'js',
             'jsx',
             'svelte',
             'ts',
             'tsx',
             'vue',
-
         ],
 
     ],
 
     'history' => [
-
         'encrypt' => false,
-
     ],
 
 ];

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -8,14 +8,10 @@ return [
     |--------------------------------------------------------------------------
     |
     | These options configures if and how Inertia uses Server Side Rendering
-    | to pre-render the initial visits made to your application's pages.
+    | to pre-render each initial request made to your application's pages
+    | so that server rendered HTML is delivered for the user's browser.
     |
-    | You can specify a custom SSR bundle path, or omit it to let Inertia
-    | try and automatically detect it for you.
-    |
-    | Do note that enabling these options will NOT automatically make SSR work,
-    | as a separate rendering service needs to be available. To learn more,
-    | please visit https://inertiajs.com/server-side-rendering
+    | See: https://inertiajs.com/server-side-rendering
     |
     */
 
@@ -33,8 +29,7 @@ return [
     |
     | The values described here are used to locate Inertia components on the
     | filesystem. For instance, when using `assertInertia`, the assertion
-    | attempts to locate the component as a file relative to any of the
-    | paths AND with any of the extensions specified here.
+    | attempts to locate the component as a file relative to the paths.
     |
     */
 
@@ -55,10 +50,6 @@ return [
             'vue',
         ],
 
-    ],
-
-    'history' => [
-        'encrypt' => false,
     ],
 
 ];


### PR DESCRIPTION
The default page path for testing pages with inertia.js is `js/Pages`. I published and changed the path to `js/pages`.

After those changes, the tests should work and run through without any fails.