### PR TITLE
Forgot password link will send if email is exists

### DIFF
--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -29,13 +29,13 @@ class PasswordResetLinkController extends Controller
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
-            'email' => 'required|email',
+            'email' => 'required|email|exists:users,email',
         ]);
 
         Password::sendResetLink(
             $request->only('email')
         );
 
-        return back()->with('status', __('A reset link will be sent if the account exists.'));
+        return back()->with('status', __('A reset link will be sent.'));
     }
 }


### PR DESCRIPTION
This PR adds validation to the forgot password functionality and updates the session message for better user clarity.

### Changes Implemented
- **Validation Added:** Implemented `exists:users,email` validation in the forgot password request to ensure only registered users can request a password reset.
- **Updated Session Message:** Changed the session message to `"A reset link will be sent."` to provide a clearer response to users.