### PR TITLE
Define route files in `bootstrap/app.php` 

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -8,7 +8,11 @@ use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__.'/../routes/web.php',
+        web: [
+            __DIR__.'/../routes/web.php',
+            __DIR__.'/../routes/settings.php',
+            __DIR__.'/../routes/auth.php',
+        ],
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,3 @@ Route::middleware(['auth', 'verified'])->group(function () {
         return Inertia::render('dashboard');
     })->name('dashboard');
 });
-
-require __DIR__.'/settings.php';
-require __DIR__.'/auth.php';


### PR DESCRIPTION
This pull request moves the route file definitions to `bootstrap/app.php`, ensuring that Laravel loads the necessary route files during the application bootstrap process. This approach provides a cleaner and more centralized way to manage route registration.

### Testing & Compatibility:
- Verified that all routes are correctly registered and accessible.
- Ensured backward compatibility with existing Laravel routing behavior.
- No breaking changes introduced.