### PR TITLE
Remove unused variables in the "workos" branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - develop
       - main
+      - workos
   pull_request:
     branches:
       - develop
       - main
+      - workos
 
 permissions:
   contents: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - develop
       - main
+      - workos
   pull_request:
     branches:
       - develop
       - main
+      - workos
 
 jobs:
   ci:

--- a/resources/js/components/delete-user.tsx
+++ b/resources/js/components/delete-user.tsx
@@ -1,17 +1,14 @@
 import { useForm } from '@inertiajs/react';
-import { FormEventHandler, useRef } from 'react';
+import { FormEventHandler } from 'react';
 
-import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 
 import HeadingSmall from '@/components/heading-small';
 
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 
 export default function DeleteUser() {
-    const { data, setData, delete: destroy, processing, reset, errors, clearErrors } = useForm();
+    const { delete: destroy, processing, reset, clearErrors } = useForm();
 
     const deleteUser: FormEventHandler = (e) => {
         e.preventDefault();

--- a/resources/js/pages/settings/profile.tsx
+++ b/resources/js/pages/settings/profile.tsx
@@ -1,6 +1,6 @@
 import { type BreadcrumbItem, type SharedData } from '@/types';
 import { Transition } from '@headlessui/react';
-import { Head, Link, useForm, usePage } from '@inertiajs/react';
+import { Head, useForm, usePage } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
 
 import DeleteUser from '@/components/delete-user';
@@ -24,7 +24,7 @@ interface ProfileForm {
     email: string;
 }
 
-export default function Profile({ status }: { status?: string }) {
+export default function Profile() {
     const { auth } = usePage<SharedData>().props;
 
     const { data, setData, patch, errors, processing, recentlySuccessful } = useForm<Required<ProfileForm>>({


### PR DESCRIPTION
This pull request fixes @typescript-eslint/no-unused-vars errors in the "workos" branch.
This change will resolve "lint" failures in GitHub Actions for projects using the "workos" branch as their base.

I also think that the "workos" branch should be included as a target in the GitHub Actions workflows.