### PR TITLE
Add PHPDoc annotations to controller methods

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -15,6 +15,9 @@ class AuthenticatedSessionController extends Controller
 {
     /**
      * Show the login page.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Inertia\Response
      */
     public function create(Request $request): Response
     {
@@ -26,6 +29,9 @@ class AuthenticatedSessionController extends Controller
 
     /**
      * Handle an incoming authentication request.
+     *
+     * @param \App\Http\Requests\Auth\LoginRequest $request
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function store(LoginRequest $request): RedirectResponse
     {
@@ -38,6 +44,9 @@ class AuthenticatedSessionController extends Controller
 
     /**
      * Destroy an authenticated session.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function destroy(Request $request): RedirectResponse
     {

--- a/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -14,6 +14,8 @@ class ConfirmablePasswordController extends Controller
 {
     /**
      * Show the confirm password page.
+     *
+     * @return \Inertia\Response
      */
     public function show(): Response
     {
@@ -22,6 +24,10 @@ class ConfirmablePasswordController extends Controller
 
     /**
      * Confirm the user's password.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\RedirectResponse
+     * @throws \Illuminate\Validation\ValidationException
      */
     public function store(Request $request): RedirectResponse
     {

--- a/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -10,6 +10,9 @@ class EmailVerificationNotificationController extends Controller
 {
     /**
      * Send a new email verification notification.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function store(Request $request): RedirectResponse
     {

--- a/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -12,6 +12,8 @@ class EmailVerificationPromptController extends Controller
 {
     /**
      * Show the email verification prompt page.
+     * @param \Illuminate\Http\Request $request
+     * @return \Inertia\Response|\Illuminate\Http\RedirectResponse
      */
     public function __invoke(Request $request): Response|RedirectResponse
     {

--- a/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -12,6 +12,7 @@ class EmailVerificationPromptController extends Controller
 {
     /**
      * Show the email verification prompt page.
+     *
      * @param \Illuminate\Http\Request $request
      * @return \Inertia\Response|\Illuminate\Http\RedirectResponse
      */

--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -18,6 +18,9 @@ class NewPasswordController extends Controller
 {
     /**
      * Show the password reset page.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Inertia\Response
      */
     public function create(Request $request): Response
     {
@@ -30,6 +33,8 @@ class NewPasswordController extends Controller
     /**
      * Handle an incoming new password request.
      *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\RedirectResponse
      * @throws \Illuminate\Validation\ValidationException
      */
     public function store(Request $request): RedirectResponse

--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -13,6 +13,9 @@ class PasswordResetLinkController extends Controller
 {
     /**
      * Show the password reset link request page.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Inertia\Response
      */
     public function create(Request $request): Response
     {
@@ -24,6 +27,8 @@ class PasswordResetLinkController extends Controller
     /**
      * Handle an incoming password reset link request.
      *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\RedirectResponse
      * @throws \Illuminate\Validation\ValidationException
      */
     public function store(Request $request): RedirectResponse

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -17,6 +17,8 @@ class RegisteredUserController extends Controller
 {
     /**
      * Show the registration page.
+     *
+     * @return \Inertia\Response
      */
     public function create(): Response
     {
@@ -26,6 +28,8 @@ class RegisteredUserController extends Controller
     /**
      * Handle an incoming registration request.
      *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\RedirectResponse
      * @throws \Illuminate\Validation\ValidationException
      */
     public function store(Request $request): RedirectResponse

--- a/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -11,6 +11,9 @@ class VerifyEmailController extends Controller
 {
     /**
      * Mark the authenticated user's email address as verified.
+     *
+     * @param \Illuminate\Foundation\Auth\EmailVerificationRequest $request
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function __invoke(EmailVerificationRequest $request): RedirectResponse
     {

--- a/app/Http/Controllers/Settings/PasswordController.php
+++ b/app/Http/Controllers/Settings/PasswordController.php
@@ -15,6 +15,9 @@ class PasswordController extends Controller
 {
     /**
      * Show the user's password settings page.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Inertia\Response
      */
     public function edit(Request $request): Response
     {
@@ -26,6 +29,9 @@ class PasswordController extends Controller
 
     /**
      * Update the user's password.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function update(Request $request): RedirectResponse
     {

--- a/app/Http/Controllers/Settings/ProfileController.php
+++ b/app/Http/Controllers/Settings/ProfileController.php
@@ -15,6 +15,9 @@ class ProfileController extends Controller
 {
     /**
      * Show the user's profile settings page.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Inertia\Response
      */
     public function edit(Request $request): Response
     {
@@ -26,6 +29,9 @@ class ProfileController extends Controller
 
     /**
      * Update the user's profile settings.
+     *
+     * @param \App\Http\Requests\Settings\ProfileUpdateRequest $request
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function update(ProfileUpdateRequest $request): RedirectResponse
     {
@@ -42,6 +48,9 @@ class ProfileController extends Controller
 
     /**
      * Delete the user's account.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function destroy(Request $request): RedirectResponse
     {


### PR DESCRIPTION
# Add PHPDoc annotations to controller methods 🧩 📝

This pull request adds complete PHPDoc annotations to all controller methods, including parameter and return type documentation. These additions improve the codebase in several ways:

## These changes cause:

1. **Enhanced IDE support** 🚀 - Provides better autocompletion, type hinting, and static analysis capabilities for developers using IDEs like PhpStorm, VS Code, etc.

2. **Improved code readability** 👓 - Makes the code more self-documenting and easier to understand, especially for new developers joining the project.

The PHPDoc style follows the conventions used in Laravel's core codebase, ensuring consistency and making this project more maintainable and easier to extend in the future. 🛠️ ✨

### Before:
![image](https://github.com/user-attachments/assets/31d05816-c330-4356-be77-4937843e7ada)

### After:
![image](https://github.com/user-attachments/assets/7605f995-36e3-4ac0-9b73-5338990d88f2)

