### PR TITLE
Add a `.prettierignore` rule to exclude `resources/views/mail/*` from formatting.  

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 resources/js/components/ui/*
 resources/js/ziggy.js
+resources/views/mail/*


### PR DESCRIPTION
Adding the `resources/views/mail/*` to the prettier ignore. A similar PR was submitted to the Vue Starter Kit here: https://github.com/laravel/vue-starter-kit/pull/77