### PR TITLE
Prevent exposing privileged info after logout

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -46,6 +46,8 @@ class AuthenticatedSessionController extends Controller
         $request->session()->invalidate();
         $request->session()->regenerateToken();
 
+        Inertia::clearHistory();
+
         return redirect('/');
     }
 }

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -52,4 +52,10 @@ return [
 
     ],
 
+    'history' => [
+
+        'encrypt' => true,
+
+    ],
+
 ];


### PR DESCRIPTION
After logout, auth-protected views are still accessible until page is refreshed.

Inertia docs warns about this behavior: https://inertiajs.com/history-encryption

## Steps to reproduce:

1. Login to dashboard page.
2. Logout.
3. Press back button in the browser.
4. Dashboard is shown again.

With this changes, it redirects to login when going back after logout.

Tested in Firefox, but surely happening in all browsers and Vue Starter Kit as well.