### PR TITLE
Fix ProfileForm definition

### DIFF
--- a/resources/js/pages/settings/profile.tsx
+++ b/resources/js/pages/settings/profile.tsx
@@ -19,7 +19,7 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-interface ProfileForm {
+type ProfileForm = {
     name: string;
     email: string;
 }


### PR DESCRIPTION
Was checking all the pages and found ProfileForm definition is not consistent with other pages.
1. https://github.com/laravel/react-starter-kit/blob/main/resources/js/pages/auth/reset-password.tsx
2. https://github.com/laravel/react-starter-kit/blob/main/resources/js/pages/auth/login.tsx