### PR TITLE
Fix Eslint config so that it uses rules from .prettierrc

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import js from '@eslint/js';
 import prettier from 'eslint-config-prettier';
+import prettierPlugin from 'eslint-plugin-prettier';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import globals from 'globals';
@@ -31,6 +32,7 @@ export default [
     {
         plugins: {
             'react-hooks': reactHooks,
+            prettier: prettierPlugin,
         },
         rules: {
             'react-hooks/rules-of-hooks': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
                 "@types/node": "^22.13.5",
                 "eslint": "^9.17.0",
                 "eslint-config-prettier": "^10.0.1",
+                "eslint-plugin-prettier": "^5.2.3",
                 "eslint-plugin-react": "^7.37.3",
                 "eslint-plugin-react-hooks": "^5.1.0",
                 "prettier": "^3.4.2",
@@ -1119,6 +1120,19 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@pkgr/core": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
+            "integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/unts"
             }
         },
         "node_modules/@radix-ui/number": {
@@ -3989,6 +4003,37 @@
                 "eslint": ">=7.0.0"
             }
         },
+        "node_modules/eslint-plugin-prettier": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.3.tgz",
+            "integrity": "sha512-qJ+y0FfCp/mQYQ/vWQ3s7eUlFEL4PyKfAJxsnYTJ4YT73nsJBWqmEpFryxV9OeUiqmsTsYJ5Y+KDNaeP31wrRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prettier-linter-helpers": "^1.0.0",
+                "synckit": "^0.9.1"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-plugin-prettier"
+            },
+            "peerDependencies": {
+                "@types/eslint": ">=8.0.0",
+                "eslint": ">=8.0.0",
+                "eslint-config-prettier": "*",
+                "prettier": ">=3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/eslint": {
+                    "optional": true
+                },
+                "eslint-config-prettier": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/eslint-plugin-react": {
             "version": "7.37.4",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.4.tgz",
@@ -4135,6 +4180,13 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/fast-diff": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+            "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
@@ -5896,6 +5948,19 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/prettier-linter-helpers": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+            "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-diff": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/prettier-plugin-organize-imports": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.1.0.tgz",
@@ -6736,6 +6801,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/synckit": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
+            "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@pkgr/core": "^0.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/unts"
             }
         },
         "node_modules/tabbable": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "@types/node": "^22.13.5",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^10.0.1",
+        "eslint-plugin-prettier": "^5.2.3",
         "eslint-plugin-react": "^7.37.3",
         "eslint-plugin-react-hooks": "^5.1.0",
         "prettier": "^3.4.2",


### PR DESCRIPTION
This enables editors (like VSCode) to check for rules present in `.prettierrc` and flag violations inline in file editors.