### PR TITLE
Fix overflow-x on AppContent

### DIFF
--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -9,7 +9,7 @@ export default function AppSidebarLayout({ children, breadcrumbs = [] }: PropsWi
     return (
         <AppShell variant="sidebar">
             <AppSidebar />
-            <AppContent variant="sidebar">
+            <AppContent variant="sidebar" className="overflow-x-hidden">
                 <AppSidebarHeader breadcrumbs={breadcrumbs} />
                 {children}
             </AppContent>

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -14,7 +14,7 @@ export default function Dashboard() {
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Dashboard" />
-            <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+            <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4 overflow-x-auto">
                 <div className="grid auto-rows-min gap-4 md:grid-cols-3">
                     <div className="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border">
                         <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />


### PR DESCRIPTION
### Reason for the PR
In every new project, I make a small but essential change: I set `overflow-x-hidden` on `AppContent`.

### Why?
Components like `shadcn/table` can cause unexpected horizontal scrolling on dashboard.tsx. To ensure a smoother experience, I want only the AppContent to be scrollable—without affecting the entire layout.

### Before (Desktop)

https://github.com/user-attachments/assets/742fbef5-e7a0-4179-9dd2-e21d0452bfa8

### After (Desktop)

https://github.com/user-attachments/assets/dbbb989a-aa56-4165-b643-e71da03d7841

### Before (Mobile)

https://github.com/user-attachments/assets/28efd8c1-134c-44d9-bd10-7c0655c5829e

### After (Mobile)

https://github.com/user-attachments/assets/548a64db-bea9-4126-bc11-577f23bd587e