### PR TITLE
Issue with session ID being refreshed twice during login

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -31,7 +31,7 @@ class AuthenticatedSessionController extends Controller
     {
         $request->authenticate();
 
-        $request->session()->regenerate();
+        $request->session()->regenerateToken();
 
         return redirect()->intended(route('dashboard', absolute: false));
     }


### PR DESCRIPTION
During login, the `Session::migrate()` function is already being called within attempt() to refresh the session ID. When regenerate() is subsequently called, it triggers `Session::migrate()` again, causing the session ID to be refreshed a second time.

This has been fixed by only calling regenerateToken().