### PR TITLE
fix(logout)!: clear Inertia prefetch cache on logout to prevent data leakage

### DIFF
--- a/resources/js/components/user-menu-content.tsx
+++ b/resources/js/components/user-menu-content.tsx
@@ -2,7 +2,7 @@ import { DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSep
 import { UserInfo } from '@/components/user-info';
 import { useMobileNavigation } from '@/hooks/use-mobile-navigation';
 import { type User } from '@/types';
-import { Link } from '@inertiajs/react';
+import { Link, router } from '@inertiajs/react';
 import { LogOut, Settings } from 'lucide-react';
 
 interface UserMenuContentProps {
@@ -11,6 +11,11 @@ interface UserMenuContentProps {
 
 export function UserMenuContent({ user }: UserMenuContentProps) {
     const cleanup = useMobileNavigation();
+
+    const handleLogout = () => {
+        cleanup();
+        router.flushAll();
+    };
 
     return (
         <>
@@ -30,7 +35,7 @@ export function UserMenuContent({ user }: UserMenuContentProps) {
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild>
-                <Link className="block w-full" method="post" href={route('logout')} as="button" onClick={cleanup}>
+                <Link className="block w-full" method="post" href={route('logout')} as="button" onClick={handleLogout}>
                     <LogOut className="mr-2" />
                     Log out
                 </Link>


### PR DESCRIPTION
## Issue

This PR fixes a potential security issue where cached data is not cleared on user logout, leading to possible data leakage in multi-user environments.

### Steps to Reproduce

> These steps should be done within less 30 seconds as the cache duration for the Settings link button is set to the [default duration](https://inertiajs.com/prefetching#:~:text=By%20default%2C%20data%20is%20cached%20for%2030%20seconds%20before%20being%20evicted.).

> Open your browser's DevTools to track prefetching requests.

1. Log in as User A.
2. Hover over the Settings link button when data will be prefetched.
3. Log out and log in as User B.
4. Upon hovering over the Settings link button, no data will be prefetched as there is already cached data about User A.
5. Clicking the Settings link button will result in showing the profile's settings **BUT** with User A's data.

### Video demonstration

https://github.com/user-attachments/assets/11f9f226-dcaa-4bf4-826a-cddb0c2a427e

## Solution

Added a call to `router.flushAll()` in the logout process to clear the Inertia prefetch cache.

### Video demonstration

https://github.com/user-attachments/assets/59eef878-2097-43b3-8c2b-0a04533f8d45
