### PR TITLE
Add `composer run test` command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,10 @@
             "npm run build:ssr",
             "Composer\\Config::disableProcessTimeout",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"php artisan inertia:start-ssr\" --names=server,queue,logs,ssr"
+        ],
+        "test": [
+            "@php artisan config:clear --ansi",
+            "@php artisan test"
         ]
     },
     "extra": {


### PR DESCRIPTION
This prevents the application from running tests with cached config.

- https://github.com/laravel/laravel/pull/6598
- https://github.com/laravel/vue-starter-kit/pull/103
- https://github.com/laravel/livewire-starter-kit/pull/81