### PR TITLE
Restore AppServiceProvider registration in the "workos" branch

### DIFF
--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,3 +1,5 @@
 <?php
 
-return [];
+return [
+    App\Providers\AppServiceProvider::class,
+];


### PR DESCRIPTION
This pull request restores the registration of AppServiceProvider in the "workos" branch.
I have confirmed that AppServiceProvider is registered in the "workos" branch of both the vue-starter-kit and livewire-starter-kit.