### PR TITLE
2FA: require password when disabling

### DIFF
--- a/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
+use Illuminate\Support\Facades\Date;
 
 class ConfirmablePasswordController extends Controller
 {
@@ -37,5 +38,24 @@ class ConfirmablePasswordController extends Controller
         $request->session()->put('auth.password_confirmed_at', time());
 
         return redirect()->intended(route('dashboard', absolute: false));
+    }
+
+    public function status(Request $request)
+    {
+        $lastConfirmation = $request->session()->get(
+            'auth.password_confirmed_at', 0
+        );
+
+        $lastConfirmed = (Date::now()->unix() - $lastConfirmation);
+
+        $confirmed = $lastConfirmed < $request->input(
+            'seconds', config('auth.password_timeout', 900)
+        );
+
+        return response()->json([
+            'confirmed' => $confirmed,
+        ], headers: array_filter([
+            'X-Retry-After' => $confirmed ? $lastConfirmed : null,
+        ]));
     }
 }

--- a/resources/js/components/confirm-password.tsx
+++ b/resources/js/components/confirm-password.tsx
@@ -3,9 +3,11 @@ import { cn } from '@/lib/utils';
 import axios from 'axios';
 import { Lock } from 'lucide-react';
 import { PropsWithChildren, useRef, useState } from 'react';
-import InputError from './input-error';
-import { Button } from './ui/button';
-import { Input } from './ui/input';
+
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useForm } from '@inertiajs/react';
 
 interface Props {
     title?: string;
@@ -14,7 +16,7 @@ interface Props {
     onConfirm(): void;
 }
 
-export function ConfirmsPassword({
+export function ConfirmPassword({
     title = 'Confirm Password',
     content = 'For your security, please confirm your password to continue.',
     button = 'Confirm',
@@ -22,7 +24,7 @@ export function ConfirmsPassword({
     children,
 }: PropsWithChildren<Props>) {
     const [confirmingPassword, setConfirmingPassword] = useState(false);
-    const [form, setForm] = useState({
+    const form = useForm({
         password: '',
         error: '',
         processing: false,
@@ -42,29 +44,23 @@ export function ConfirmsPassword({
     }
 
     function confirmPassword() {
-        setForm({ ...form, processing: true });
-
         axios
             .post(route('password.confirm'), {
-                password: form.password,
+                password: form.data.password,
             })
             .then(() => {
                 closeModal();
                 setTimeout(() => onConfirm(), 250);
             })
             .catch((error) => {
-                setForm({
-                    ...form,
-                    processing: false,
-                    error: error.response.data.errors.password[0],
-                });
+                form.setError('password', error.response.data.errors.password[0]);
                 passwordRef.current?.focus();
             });
     }
 
     function closeModal() {
         setConfirmingPassword(false);
-        setForm({ processing: false, password: '', error: '' });
+        form.reset();
     }
 
     return (
@@ -91,10 +87,10 @@ export function ConfirmsPassword({
                                 type="password"
                                 className="mt-1 block w-full"
                                 placeholder="Password"
-                                value={form.password}
-                                onChange={(e) => setForm({ ...form, password: e.currentTarget.value })}
+                                value={form.data.password}
+                                onChange={(e) => form.setData('password', e.currentTarget.value)}
                             />
-                            <InputError message={form.error} className="mt-2" />
+                            <InputError message={form.errors.password} className="mt-2" />
                         </div>
                     </div>
                     <DialogFooter>

--- a/resources/js/components/confirms-password.tsx
+++ b/resources/js/components/confirms-password.tsx
@@ -1,0 +1,113 @@
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+import axios from 'axios';
+import { Lock } from 'lucide-react';
+import { PropsWithChildren, useRef, useState } from 'react';
+import InputError from './input-error';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+
+interface Props {
+    title?: string;
+    content?: string;
+    button?: string;
+    onConfirm(): void;
+}
+
+export function ConfirmsPassword({
+    title = 'Confirm Password',
+    content = 'For your security, please confirm your password to continue.',
+    button = 'Confirm',
+    onConfirm,
+    children,
+}: PropsWithChildren<Props>) {
+    const [confirmingPassword, setConfirmingPassword] = useState(false);
+    const [form, setForm] = useState({
+        password: '',
+        error: '',
+        processing: false,
+    });
+    const passwordRef = useRef<HTMLInputElement>(null);
+
+    function startConfirmingPassword() {
+        axios.get(route('password.confirmation')).then((response) => {
+            if (response.data.confirmed) {
+                onConfirm();
+            } else {
+                setConfirmingPassword(true);
+
+                setTimeout(() => passwordRef.current?.focus(), 250);
+            }
+        });
+    }
+
+    function confirmPassword() {
+        setForm({ ...form, processing: true });
+
+        axios
+            .post(route('password.confirm'), {
+                password: form.password,
+            })
+            .then(() => {
+                closeModal();
+                setTimeout(() => onConfirm(), 250);
+            })
+            .catch((error) => {
+                setForm({
+                    ...form,
+                    processing: false,
+                    error: error.response.data.errors.password[0],
+                });
+                passwordRef.current?.focus();
+            });
+    }
+
+    function closeModal() {
+        setConfirmingPassword(false);
+        setForm({ processing: false, password: '', error: '' });
+    }
+
+    return (
+        <>
+            <Dialog open={confirmingPassword} onOpenChange={setConfirmingPassword}>
+                <DialogTrigger asChild>
+                    <span onClick={startConfirmingPassword}>{children}</span>
+                </DialogTrigger>
+                <DialogContent className="sm:max-w-md">
+                    <DialogHeader className="flex items-center justify-center">
+                        <div className="mb-3 w-auto rounded-full border border-stone-100 bg-white p-0.5 shadow-sm dark:border-stone-600 dark:bg-stone-800">
+                            <div className="relative overflow-hidden rounded-full border border-stone-200 bg-stone-100 p-2.5 dark:border-stone-600 dark:bg-stone-200">
+                                <Lock className="relative z-20 size-5 dark:text-black" />
+                            </div>
+                        </div>
+                        <DialogTitle>{title}</DialogTitle>
+                        <DialogDescription className="text-center">{content}</DialogDescription>
+                    </DialogHeader>
+
+                    <div className="relative mb-6 flex w-full flex-col items-center justify-center space-y-5">
+                        <div className="mt-4">
+                            <Input
+                                ref={passwordRef}
+                                type="password"
+                                className="mt-1 block w-full"
+                                placeholder="Password"
+                                value={form.password}
+                                onChange={(e) => setForm({ ...form, password: e.currentTarget.value })}
+                            />
+                            <InputError message={form.error} className="mt-2" />
+                        </div>
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={closeModal}>
+                            Cancel
+                        </Button>
+
+                        <Button className={cn('ml-2', { 'opacity-25': form.processing })} onClick={confirmPassword} disabled={form.processing}>
+                            {button}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}

--- a/resources/js/pages/settings/two-factor.tsx
+++ b/resources/js/pages/settings/two-factor.tsx
@@ -16,7 +16,7 @@ import {
 import { Check, Copy, Eye, EyeOff, Loader, ScanLine, LockKeyhole } from 'lucide-react';
 import { useTwoFactorAuth } from '@/hooks/use-two-factor-auth';
 import type { BreadcrumbItem } from '@/types';
-import { ConfirmsPassword } from '@/components/confirms-password';
+import { ConfirmPassword } from '@/components/confirm-password';
 
 interface TwoFactorProps {
     confirmed: boolean;
@@ -295,13 +295,13 @@ export default function TwoFactor({ confirmed: initialConfirmed, recoveryCodes }
                             </div>
 
                             <div className="inline relative">
-                                <ConfirmsPassword
+                                <ConfirmPassword
                                     onConfirm={disable}
                                 >
                                     <Button variant="destructive">
                                         Disable 2FA
                                     </Button>
-                                </ConfirmsPassword>
+                                </ConfirmPassword>
                             </div>
                         </div>
                     )}

--- a/resources/js/pages/settings/two-factor.tsx
+++ b/resources/js/pages/settings/two-factor.tsx
@@ -16,6 +16,7 @@ import {
 import { Check, Copy, Eye, EyeOff, Loader, ScanLine, LockKeyhole } from 'lucide-react';
 import { useTwoFactorAuth } from '@/hooks/use-two-factor-auth';
 import type { BreadcrumbItem } from '@/types';
+import { ConfirmsPassword } from '@/components/confirms-password';
 
 interface TwoFactorProps {
     confirmed: boolean;
@@ -294,9 +295,13 @@ export default function TwoFactor({ confirmed: initialConfirmed, recoveryCodes }
                             </div>
 
                             <div className="inline relative">
-                                <Button variant="destructive" onClick={disable}>
-                                    Disable 2FA
-                                </Button>
+                                <ConfirmsPassword
+                                    onConfirm={disable}
+                                >
+                                    <Button variant="destructive">
+                                        Disable 2FA
+                                    </Button>
+                                </ConfirmsPassword>
                             </div>
                         </div>
                     )}

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -50,6 +50,9 @@ Route::middleware('auth')->group(function () {
     Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
         ->name('password.confirm');
 
+    Route::get('confirm-password/status', [ConfirmablePasswordController::class, 'status'])
+        ->name('password.confirmation');
+
     Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -20,7 +20,8 @@ Route::middleware('auth')->group(function () {
     Route::post('settings/two-factor', [TwoFactorAuthController::class, 'enable'])->name('two-factor.enable');
     Route::post('settings/two-factor/confirm', [TwoFactorAuthController::class, 'confirm'])->name('two-factor.confirm');
     Route::post('settings/two-factor/recovery-codes', [TwoFactorAuthController::class, 'regenerateRecoveryCodes'])->name('two-factor.regenerate-recovery-codes');
-    Route::delete('settings/two-factor', [TwoFactorAuthController::class, 'disable'])->name('two-factor.disable');
+    Route::delete('settings/two-factor', [TwoFactorAuthController::class, 'disable'])->name('two-factor.disable')
+        ->middleware('password.confirm');
 
     Route::get('settings/appearance', function () {
         return Inertia::render('settings/appearance');


### PR DESCRIPTION
I feel like it's a little too easy to disable 2FA without entering in a password. It does so by creating a reusable dialog and leveraging the existing `password.confirm` middleware.