### PR TITLE
CORS fixing on local development with Laravel valet

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import laravel from 'laravel-vite-plugin';
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 
-export default defineConfig({
+export default defineConfig( ({ command }) => ({
     plugins: [
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.tsx'],
@@ -14,9 +14,9 @@ export default defineConfig({
         react(),
         tailwindcss(),
     ],
-    server: {
+    server: command === 'serve' ? {
         cors: true,
-    },
+    } : {},
     esbuild: {
         jsx: 'automatic',
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,4 +25,4 @@ export default defineConfig( ({ command }) => ({
             'ziggy-js': resolve(__dirname, 'vendor/tightenco/ziggy'),
         },
     },
-});
+}));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
         react(),
         tailwindcss(),
     ],
+    server: {
+        cors: true,
+    },
     esbuild: {
         jsx: 'automatic',
     },


### PR DESCRIPTION
On the local development that uses something like Laravel Valet,

When we run `npm run dev`, the JavaScript is likely being rejected by the browser due to the different domain and port, so it will display a blank page.

We only allow CORS on the `development`, on the ' build `npm build` process, it will not allow the script to use CORS.

