### PR TITLE
Fix strict comparison 

### DIFF
--- a/resources/js/components/nav-main.tsx
+++ b/resources/js/components/nav-main.tsx
@@ -10,8 +10,9 @@ export function NavMain({ items = [] }: { items: NavItem[] }) {
             <SidebarMenu>
                 {items.map((item) => (
                     <SidebarMenuItem key={item.title}>
-                        <SidebarMenuButton  
-                            asChild isActive={item.href === page.url}
+                        <SidebarMenuButton
+                            asChild
+                            isActive={page.url.startsWith(item.href)}
                             tooltip={{ children: item.title }}
                         >
                             <Link href={item.href} prefetch>


### PR DESCRIPTION
Fix strict comparison between current page URL and navigation item URL. Strict comparison broke active navbar highlighting when a query parameter was added to the URL.