### PR TITLE
gitignore: add .env.testing to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .env
 .env.backup
 .env.production
+.env.testing
 .phpactor.json
 .phpunit.result.cache
 Homestead.json


### PR DESCRIPTION
### Why this PR?

- I always add `.env.testing` to `.gitignore` on all my projects — it’s a small thing that just makes life easier.
- Since issues and discussions are disabled in the starter kits, I thought a simple PR to all three would be the best way to suggest it.
- Laravel automatically picks up `.env.testing` to keep testing configs separate.
- Adding it to `.gitignore` helps avoid accidentally committing sensitive or local test environment details.
- Honestly, not sure why this isn’t already included by default.
