### PR TITLE
Redirect the user to the URL they were attempting to access before registering

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -46,6 +46,6 @@ class RegisteredUserController extends Controller
 
         Auth::login($user);
 
-        return to_route('dashboard');
+        return redirect()->intended(route('dashboard', absolute: false));
     }
 }


### PR DESCRIPTION
Redirect the user to the URL they were attempting to access before being intercepted by the authentication middleware.
This works if the user clicks on the **“Register”** page from the **“Login”** page.

**A typical scenario:**

  1. The user starts the **Authorization Code Grant** flow with Passport on the `/oauth/authorize` URL.
  2. If the user is **not authenticated**, they are redirected to the **login page**.
  3. On the **login page**, if the user doesn’t have an account, they can click on the **register page**.
  4. On the **register page**, after successfully creating an account, the user is redirected back to the **authorize page (/oauth/authorize)** to resume the OAuth authorization process.
