### PR TITLE
Enhance dynamic page title generation with fallback to app name

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -8,7 +8,7 @@ import { initializeTheme } from './hooks/use-appearance';
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
 createInertiaApp({
-    title: (title) => `${title} - ${appName}`,
+    title: (title) => title ? `${title} - ${appName}` : appName,
     resolve: (name) => resolvePageComponent(`./pages/${name}.tsx`, import.meta.glob('./pages/**/*.tsx')),
     setup({ el, App, props }) {
         const root = createRoot(el);

--- a/resources/js/ssr.tsx
+++ b/resources/js/ssr.tsx
@@ -10,7 +10,7 @@ createServer((page) =>
     createInertiaApp({
         page,
         render: ReactDOMServer.renderToString,
-        title: (title) => `${title} - ${appName}`,
+        title: (title) => title ? `${title} - ${appName}` : appName,
         resolve: (name) => resolvePageComponent(`./pages/${name}.tsx`, import.meta.glob('./pages/**/*.tsx')),
         setup: ({ App, props }) => {
             /* eslint-disable */


### PR DESCRIPTION
Updated the title function to support pages without a custom title.
Now, if no title is provided, it will default to displaying only the appName.
This improves consistency across routes and prevents malformed titles like `- AppName`.

Before:

```ts
title: (title) => `${title} - ${appName}`
```

After:

```ts
title: (title) => title ? `${title} - ${appName}` : appName
```