### PR TITLE
fix: improve hover animations by disabling user selection and pointer events

### DIFF
--- a/resources/js/components/ui/sidebar.tsx
+++ b/resources/js/components/ui/sidebar.tsx
@@ -401,7 +401,7 @@ function SidebarGroupLabel({
       data-sidebar="group-label"
       className={cn(
         "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:select-none group-data-[collapsible=icon]:pointer-events-none",
         className
       )}
       {...props}


### PR DESCRIPTION
When the sidebar is collapsed, some parts of the icon buttons become unclickable due to the label overlapping them. This Pull Request aims to resolve that issue. Below are some screenshots that illustrate the problem in more detail.

![image](https://github.com/user-attachments/assets/907b4391-cd2e-4bf7-a2f7-e53c27dc714d)
![image](https://github.com/user-attachments/assets/a0868ae8-2c04-44f8-beb3-f0b50fed8660)

#### After the fix:
![image](https://github.com/user-attachments/assets/52bd6fe8-886a-48a8-9156-b42be28fe1bc)
![image](https://github.com/user-attachments/assets/8f1696a8-b31a-43cb-a28e-bc996bb627bb)



