### PR TITLE
Use and show the icon of sidebarNavItems in the settings sidebar

### DIFF
--- a/resources/js/layouts/settings/layout.tsx
+++ b/resources/js/layouts/settings/layout.tsx
@@ -50,6 +50,7 @@ export default function SettingsLayout({ children }: PropsWithChildren) {
                                 })}
                             >
                                 <Link href={item.href} prefetch>
+                                    {item.icon && <item.icon className="h-4 w-4" />}
                                     {item.title}
                                 </Link>
                             </Button>


### PR DESCRIPTION
## Changes
Add icon rendering for sidebar items that already had icons defined ([here](https://github.com/laravel/react-starter-kit/blob/f1c4c46e411b59755c7ec377a34dc41567b2aa1c/resources/js/layouts/settings/layout.tsx#L13)) but weren't being displayed.
