### PR TITLE
Refactor layout styles for improved responsiveness

### DIFF
--- a/resources/js/layouts/settings/layout.tsx
+++ b/resources/js/layouts/settings/layout.tsx
@@ -36,7 +36,7 @@ export default function SettingsLayout({ children }: PropsWithChildren) {
         <div className="px-4 py-6">
             <Heading title="Settings" description="Manage your profile and account settings" />
 
-            <div className="flex flex-col space-y-8 lg:flex-row lg:space-y-0 lg:space-x-12">
+            <div className="flex flex-col lg:flex-row lg:space-x-12">
                 <aside className="w-full max-w-xl lg:w-48">
                     <nav className="flex flex-col space-y-1 space-x-0">
                         {sidebarNavItems.map((item, index) => (
@@ -57,7 +57,7 @@ export default function SettingsLayout({ children }: PropsWithChildren) {
                     </nav>
                 </aside>
 
-                <Separator className="my-6 md:hidden" />
+                <Separator className="my-6 lg:hidden" />
 
                 <div className="flex-1 md:max-w-2xl">
                     <section className="max-w-xl space-y-12">{children}</section>


### PR DESCRIPTION
This fixes the layout issue on the settings layout that I originally found and fixed [for the Vue starter kit repository](https://github.com/laravel/vue-starter-kit/pull/165). I decided to fix this in the React template. Only the React and Vue templates were impacted by this, as the livewire template does not have the same layout.


See https://github.com/laravel/vue-starter-kit/pull/165 for reference.