### PR TITLE
Change style from 'default' to 'new-york'

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://ui.shadcn.com/schema.json",
-    "style": "default",
+    "style": "new-york",
     "rsc": false,
     "tsx": true,
     "tailwind": {


### PR DESCRIPTION
The `default` style has been deprecated. Use the `new-york` style instead, [according to docs](https://ui.shadcn.com/docs/components-json#style)