### PR TITLE
Update prettier import path in eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
 import js from '@eslint/js';
-import prettier from 'eslint-config-prettier';
+import prettier from 'eslint-config-prettier/flat';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import globals from 'globals';


### PR DESCRIPTION
Consider adding `flat` for `eslint-config-prettier` imort as it will show better when lanuch the config-inspector tool see [docs](https://github.com/prettier/eslint-config-prettier?tab=readme-ov-file#installation)