### PR TITLE
Simplify Vite entry in app.blade.php

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -40,7 +40,7 @@
         <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
 
         @viteReactRefresh
-        @vite(['resources/js/app.tsx', "resources/js/pages/{$page['component']}.tsx"])
+        @vite(['resources/js/app.tsx'])
         @inertiaHead
     </head>
     <body class="font-sans antialiased">


### PR DESCRIPTION
Currently shows error when reloading a page. e.g. 
<img width="1427" height="609" alt="image" src="https://github.com/user-attachments/assets/af4fa1f5-e32b-4fc1-a9db-74055e37e260" />

This pull request makes a small update to the asset loading in the `app.blade.php` layout file. The change updates the Vite asset inclusion by only loading the main `app.tsx` file, rather than also including a page-specific JavaScript file, which leads to breaking page reloads on production build i.e. `npm run build` . 

