### PR TITLE
Removed the tailwind.config value from components.json

### DIFF
--- a/components.json
+++ b/components.json
@@ -4,7 +4,7 @@
     "rsc": false,
     "tsx": true,
     "tailwind": {
-        "config": "tailwind.config.js",
+        "config": "",
         "css": "resources/css/app.css",
         "baseColor": "neutral",
         "cssVariables": true,


### PR DESCRIPTION
I can't explain why, it's kind of beyond my comprehension, but when running the command `npx shadcn@latest add card` it only gets the correct component when this config value is an empty string. Could it be something about a missing file? I don't know, but I've spent an hour debugging why it wouldn't fetch the correct component and this fixed it.

Example:

When the value is `tailwind.config.js` it downloads this:
```
const Card = React.forwardRef<
  HTMLDivElement,
  React.HTMLAttributes<HTMLDivElement>
>(({ className, ...props }, ref) => (
  <div
    ref={ref}
    className={cn(
      "rounded-lg border bg-card text-card-foreground shadow-sm",
      className
    )}
    {...props}
  />
))
Card.displayName = "Card"
```

And when the value is an empty string it gets this:
```
function Card({ className, ...props }: React.ComponentProps<"div">) {
  return (
    <div
      data-slot="card"
      className={cn(
        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
        className
      )}
      {...props}
    />
  )
}
```