### PR TITLE
fix(seeder): prevent duplicate user on db:seed 

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -15,9 +16,13 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        User::firstOrCreate(
+            ['email' => 'test@example.com'],
+            [
+                'name' => 'Test User',
+                'password' => Hash::make('password'),
+                'email_verified_at' => now(),
+            ]
+        );
     }
 }


### PR DESCRIPTION
The DatabaseSeeder used User::factory()->create() and failed when running php artisan db:seed multiple times due to the unique email constraint.

<img width="1285" height="496" alt="Captura de tela 2025-09-13 024751" src="https://github.com/user-attachments/assets/769c15d2-66d3-4841-baf3-4c836ad8cbf2" />

It was updated to User::firstOrCreate() to ensure idempotency:

- No duplicate users are created.
- A predictable default user is always available (test@example.com / password).

Now it has no problems and does not break when running it multiple times.

<img width="555" height="350" alt="Captura de tela 2025-09-13 025442" src="https://github.com/user-attachments/assets/68314efe-4cdb-4480-97d6-319cc7f41ef2" />