### PR TITLE
prevent sidebar state reset during Inertia prefetching

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -45,7 +45,6 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $request->user(),
             ],
-            'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
         ];
     }
 }


### PR DESCRIPTION
**Problem**
Sidebar state resets unexpectedly when hovering over prefetch-enabled links due to server-side state overriding client-side state.

**Solution**
Move sidebar state management entirely to client-side:

- Added getCookieValue() helper for client-side cookie reading
- Enhanced SidebarProvider initialization from cookies
- Added state synchronization effect