### PR TITLE
fix header menu selection indicator not showing

### DIFF
--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -182,7 +182,10 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                                             )}
                                             {item.title}
                                         </Link>
-                                        {page.url === item.href && (
+                                        {page.url ===
+                                            (typeof item.href === 'string'
+                                                ? item.href
+                                                : item.href.url) && (
                                             <div className="absolute bottom-0 left-0 h-0.5 w-full translate-y-px bg-black dark:bg-white"></div>
                                         )}
                                     </NavigationMenuItem>


### PR DESCRIPTION
The way that we assert that a menu is active changed on the following commit (https://github.com/laravel/react-starter-kit/commit/21e50ce8991222c9e2e0e913bcdde4dc904ae313#diff-e93188a864f7af449d4b29df16b91db77b206f891eef34b28856d7b5565e537dL111-R112) to use wayfinder but the same condition was not being applied on the active menu selector, this PR fixes it.