### PR TITLE
Add data-test attribute to sidebar menu button for testing

### DIFF
--- a/resources/js/components/nav-user.tsx
+++ b/resources/js/components/nav-user.tsx
@@ -29,6 +29,7 @@ export function NavUser() {
                         <SidebarMenuButton
                             size="lg"
                             className="group text-sidebar-accent-foreground data-[state=open]:bg-sidebar-accent"
+                            data-test="sidebar-menu-button"
                         >
                             <UserInfo user={auth.user} />
                             <ChevronsUpDown className="ml-auto size-4" />


### PR DESCRIPTION
This MR fix the flaky logout test by adding the data-test attribute on the sidebar menu button for more reliable testing.