### PR TITLE
chore: add cast for two_factor_confirmed_at

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -44,6 +44,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'two_factor_confirmed_at' => 'datetime',
         ];
     }
 }


### PR DESCRIPTION
As per title, since now there's the new timestamp it might be useful to have it automatically cast as datetime